### PR TITLE
HPM115S0 Sensor always reports 0

### DIFF
--- a/WeatherStation/src/src/uart_pm_sensors/uart_pm_sensors.cpp
+++ b/WeatherStation/src/src/uart_pm_sensors/uart_pm_sensors.cpp
@@ -167,6 +167,8 @@ bool UART_PM_Sensors::GetParticleCount( float* value, UART_PM_Sensors::ParticleS
             case SENSOR_HPM115S0:{
                 if(HPMA115S0device != nullptr){
                     reading_ok=HPMA115S0device->ReadMesurement(&up25, &up10);
+					p25 = up25;
+                    p10 = up25;
                 }
             } break;
 


### PR DESCRIPTION
Fixed an issue where the result is never assigned from up25 and up10 which causes the value to always be returned as zero.